### PR TITLE
04 Add Docker Compose file with the separate DockerFile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.8'
+
+services:
+  db:
+    build:
+      context: ./db
+      dockerfile: Dockerfile
+    container_name: taskly-db
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    env_file:
+      - .env
+    networks:
+      - taskly-backend-network
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: taskly-backend
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    env_file:
+      - .env
+    volumes:
+      - ./backend:/app
+    networks:
+      - taskly-backend-network
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: taskly-frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+    volumes:
+      - ./frontend:/app
+      - node_modules:/frontend/app/node_modules
+    networks:
+      - taskly-frontend-network
+
+volumes:
+  db_data:
+  node_modules:
+
+networks:
+  taskly-backend-network:
+  taskly-frontend-network:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,9 @@
         "vite-plugin-vue-devtools": "^7.5.4",
         "vitest": "^2.1.4",
         "vue-tsc": "^2.1.10"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-arm64-musl": "^4.27.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1395,7 +1398,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1535,9 +1537,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+      "integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.8"
@@ -6362,9 +6364,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,5 +43,8 @@
     "vite-plugin-vue-devtools": "^7.5.4",
     "vitest": "^2.1.4",
     "vue-tsc": "^2.1.10"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-arm64-musl": "^4.27.3"
   }
 }


### PR DESCRIPTION
### 📓 PR description
This PR resolves the hassle of running 3 different docker containers separately for FE, BE, and DB. We are introducing a docker-compose.yml file which consists of all the necessary commands, and instructions to run the container all together.

### ✅ Works Done
- [x] added docker-compose file
- [x] successfully ran `docker-compose up --build` to run the containers

### 🔧 How to Test
in the console just run `docker-compose up --build` then browse the 
1️⃣ localhost:8000/docs => BE
2️⃣ localhost:5173 => FE

### 🚀 Next Works
- [ ] add search bar for filtering the items
- [ ] create a .env_example

### 📷 Before SS


### 📸 After SS
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/619e694b-5d33-480a-97ec-d24cb128ecd2">
